### PR TITLE
Fix static url to accept the PREFIX_URL

### DIFF
--- a/web/tais/settings.py
+++ b/web/tais/settings.py
@@ -130,7 +130,7 @@ PREFIX_URL = os.getenv('PREFIX_URL', '')
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = '/{}static/'.format(PREFIX_URL)
 STATICFILES_DIRS = [
     os.path.join(PROJECT_BASE_DIR, 'static'),
 ]


### PR DESCRIPTION
Isso é necessário para que os arquivos estaticos sejam carregados se a url tiver prefixo