### PR TITLE
fix(KIBANA-WEB): fixed auth validors

### DIFF
--- a/kibana-web/tais/settings.py
+++ b/kibana-web/tais/settings.py
@@ -95,16 +95,20 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        'NAME': ('django.contrib.auth.password_validation'
+                 '.UserAttributeSimilarityValidator')
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'NAME': ('django.contrib.auth.password_validation'
+                 '.MinimumLengthValidator'),
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        'NAME': ('django.contrib.auth.password_validation'
+                 '.CommonPasswordValidator'),
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        'NAME': ('django.contrib.auth.password_validation'
+                 '.NumericPasswordValidator'),
     },
 ]
 

--- a/kibana-web/tais/settings.py
+++ b/kibana-web/tais/settings.py
@@ -95,20 +95,16 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation \
-                       .UserAttributeSimilarityValidator',
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
     },
     {
-        'NAME': 'django.contrib.auth \
-                       .password_validation.MinimumLengthValidator',
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
     },
     {
-        'NAME': 'django.contrib.auth \
-                       .password_validation.CommonPasswordValidator',
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
     },
     {
-        'NAME': 'django.contrib.auth \
-                       .password_validation.NumericPasswordValidator',
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]
 


### PR DESCRIPTION
## Descrição

Esse commit corrige a declaração de **AUTH_PASSWORD_VALIDATORS** dentro da pasta kibana-web.

Nas outras pastas já estava no padrão correto sendo necessário somente corrigir essa

### Como Era

```python
AUTH_PASSWORD_VALIDATORS = [
    {
        'NAME': 'django.contrib.auth.password_validation \
                       .UserAttributeSimilarityValidator',
    },
    {
        'NAME': 'django.contrib.auth \
                       .password_validation.MinimumLengthValidator',
    },
    {
        'NAME': 'django.contrib.auth \
                       .password_validation.CommonPasswordValidator',
    },
    {
        'NAME': 'django.contrib.auth \
                       .password_validation.NumericPasswordValidator',
    },
]
```


### Como Ficou

```python
AUTH_PASSWORD_VALIDATORS = [
    {
        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
    },
    {
        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
    },
    {
        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
    },
    {
        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
    },
]
```

## Informações complementares

Cheguei nesse error a partir do log

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/django/contrib/auth/password_validation.py", line 26, in get_password_validators
    klass = import_string(validator['NAME'])
  File "/usr/local/lib/python3.6/site-packages/django/utils/module_loading.py", line 17, in import_string
    module = import_module(module_path)
  File "/usr/local/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'django.contrib.auth.password_validation                        '

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.6/site-packages/django/contrib/auth/management/commands/createsuperuser.py", line 61, in execute
    return super().execute(*args, **options)
  File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.6/site-packages/django/contrib/auth/management/commands/createsuperuser.py", line 132, in handle
    validate_password(password2, self.UserModel(**fake_user_data))
  File "/usr/local/lib/python3.6/site-packages/django/contrib/auth/password_validation.py", line 44, in validate_password
    password_validators = get_default_password_validators()
  File "/usr/local/lib/python3.6/site-packages/django/contrib/auth/password_validation.py", line 19, in get_default_password_validators
    return get_password_validators(settings.AUTH_PASSWORD_VALIDATORS)
  File "/usr/local/lib/python3.6/site-packages/django/contrib/auth/password_validation.py", line 29, in get_password_validators
    raise ImproperlyConfigured(msg % validator['NAME'])
django.core.exceptions.ImproperlyConfigured: The module in NAME could not be imported: django.contrib.auth.password_validation                        .UserAttributeSimilarityValidator. Check your AUTH_PASSWORD_VALIDATORS setting.
```

### Solução

Verifiquei nos outros arquivos de **settings.py** que esse não era o padrão de declarar validators

### Fonte de Pesquisa

Validei a solução a partir desse link no Stack overflow

* https://stackoverflow.com/questions/53546995/error-when-creating-admin-in-django-tutorial