### PR TITLE
Optimizes GitLabCI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ test stories:
    - docker:dind
  script:
    - docker build . -f docker/bot/coach.Dockerfile -t $COACH_TEMP_IMAGE > /dev/null 2>&1
-   - docker build -f docker/bot/bot.Dockerfile -t $COACH_BOT_IMAGE .
+   - docker build -f docker/bot/bot.Dockerfile -t $BOT_TEMP_IMAGE .
    - docker run --rm $BOT_TEMP_IMAGE make test-stories
    - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
    - docker push $COACH_TEMP_IMAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,15 @@
 image: python:3.6-slim
 
+variables:
+  COACH_TEMP_IMAGE: $CI_REGISTRY_IMAGE/ci/coach:$CI_COMMIT_SHORT_SHA
+  BOT_TEMP_IMAGE: $CI_REGISTRY_IMAGE/ci/bot:$CI_COMMIT_SHORT_SHA
+
+
 stages:
   - test style
   - validate format
-  # - test stories
   - build requirements
+  - test stories
   - build coach
   - build
   - deploy
@@ -29,17 +34,21 @@ run dataset validator:
     - cd coach/
     - make run-validator
 
-#test stories:
-#  stage: test stories
-#  image: docker
-#  tags:
-#    - docker
-#  services:
-#    - docker:dind
-#  script:
-#    - docker build . -f docker/bot/coach.Dockerfile -t lappis/coach:latest > /dev/null 2>&1
-#    - docker build -f docker/bot/bot.Dockerfile -t lappis/bot:latest .
-#    - docker run --rm lappis/bot:latest make test-stories
+test stories:
+ stage: test stories
+ image: docker
+ tags:
+   - docker
+ services:
+   - docker:dind
+ script:
+   - docker build . -f docker/bot/coach.Dockerfile -t $COACH_TEMP_IMAGE > /dev/null 2>&1
+   - docker build -f docker/bot/bot.Dockerfile -t $COACH_BOT_IMAGE .
+   - docker run --rm $BOT_TEMP_IMAGE make test-stories
+   - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
+   - docker push $COACH_TEMP_IMAGE
+   - docker push $BOT_TEMP_IMAGE
+
 
 build requirements:
   stage: build requirements
@@ -68,10 +77,13 @@ build coach:
     - docker:dind
   script:
     - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
-    - docker build . -f docker/bot/coach.Dockerfile -t lappis/coach:latest > /dev/null 2>&1
+    # - docker build . -f docker/bot/coach.Dockerfile -t lappis/coach:latest > /dev/null 2>&1
+    - docker pull $COACH_TEMP_IMAGE
+    - docker tag $COACH_TEMP_IMAGE lappis/coach:latest
     - docker push lappis/coach:latest
   only:
     - master
+    - gitlabci_optimization
   environment: homolog
 
 build bot:
@@ -83,10 +95,13 @@ build bot:
     - docker:dind
   script:
     - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
-    - docker build -f docker/bot/bot.Dockerfile -t lappis/bot:latest .
+    # - docker build -f docker/bot/bot.Dockerfile -t lappis/bot:latest .
+    - docker pull $BOT_TEMP_IMAGE
+    - docker tag $BOT_TEMP_IMAGE lappis/bot:latest
     - docker push lappis/bot:latest
   only:
     - master
+    - gitlabci_optimization
   environment: homolog
 
 build web:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,11 +42,12 @@ test stories:
  services:
    - docker:dind
  script:
-   - docker build . -f docker/bot/coach.Dockerfile -t $COACH_TEMP_IMAGE > /dev/null 2>&1
-   - docker build -f docker/bot/bot.Dockerfile -t $BOT_TEMP_IMAGE .
+   - docker build . -f docker/bot/coach.Dockerfile -t lappis/coach:latest > /dev/null 2>&1 # Builds lappis/coach:latest
+   - docker build -f docker/bot/bot.Dockerfile -t $BOT_TEMP_IMAGE . # It uses lappis/coach:latest built locally
    - docker run --rm $BOT_TEMP_IMAGE make test-stories
    - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
-   - docker push $COACH_TEMP_IMAGE
+   - docker tag lappis/coach:latest $COACH_TEMP_IMAGE # Retags lappis/coach:latest to temp image
+   - docker push $COACH_TEMP_IMAGE # Pushes temp image to the gitlab registry (it will be pulled from gitlab and pushed to Dockerhub later)
    - docker push $BOT_TEMP_IMAGE
 
 
@@ -77,13 +78,11 @@ build coach:
     - docker:dind
   script:
     - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
-    # - docker build . -f docker/bot/coach.Dockerfile -t lappis/coach:latest > /dev/null 2>&1
     - docker pull $COACH_TEMP_IMAGE
     - docker tag $COACH_TEMP_IMAGE lappis/coach:latest
     - docker push lappis/coach:latest
   only:
     - master
-    - gitlabci_optimization
   environment: homolog
 
 build bot:
@@ -95,13 +94,11 @@ build bot:
     - docker:dind
   script:
     - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
-    # - docker build -f docker/bot/bot.Dockerfile -t lappis/bot:latest .
     - docker pull $BOT_TEMP_IMAGE
     - docker tag $BOT_TEMP_IMAGE lappis/bot:latest
     - docker push lappis/bot:latest
   only:
     - master
-    - gitlabci_optimization
   environment: homolog
 
 build web:


### PR DESCRIPTION
Now, there bot training occurs only before testing. Instead of rebuilding the images, the subsequent stages pull, from GitLab Registry, the previously built images, retag and upload them to Dockerhub.