### PR TITLE
Changes docker "latest" tags to "tais" tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ test style:
 
 run dataset validator:
   stage: validate format
-  image: lappis/coach:latest
+  image: lappis/coach:tais
   script:
     - cd coach/
     - make run-validator
@@ -42,11 +42,11 @@ test stories:
  services:
    - docker:dind
  script:
-   - docker build . -f docker/bot/coach.Dockerfile -t lappis/coach:latest > /dev/null 2>&1 # Builds lappis/coach:latest
-   - docker build -f docker/bot/bot.Dockerfile -t $BOT_TEMP_IMAGE . # It uses lappis/coach:latest built locally
+   - docker build . -f docker/bot/coach.Dockerfile -t lappis/coach:tais > /dev/null 2>&1 # Builds lappis/coach:tais
+   - docker build -f docker/bot/bot.Dockerfile -t $BOT_TEMP_IMAGE . # It uses lappis/coach:tais built locally
    - docker run --rm $BOT_TEMP_IMAGE make test-stories
    - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
-   - docker tag lappis/coach:latest $COACH_TEMP_IMAGE # Retags lappis/coach:latest to temp image
+   - docker tag lappis/coach:tais $COACH_TEMP_IMAGE # Retags lappis/coach:tais to temp image
    - docker push $COACH_TEMP_IMAGE # Pushes temp image to the gitlab registry (it will be pulled from gitlab and pushed to Dockerhub later)
    - docker push $BOT_TEMP_IMAGE
 
@@ -79,8 +79,8 @@ build coach:
   script:
     - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
     - docker pull $COACH_TEMP_IMAGE
-    - docker tag $COACH_TEMP_IMAGE lappis/coach:latest
-    - docker push lappis/coach:latest
+    - docker tag $COACH_TEMP_IMAGE lappis/coach:tais
+    - docker push lappis/coach:tais
   only:
     - master
   environment: homolog
@@ -95,8 +95,8 @@ build bot:
   script:
     - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
     - docker pull $BOT_TEMP_IMAGE
-    - docker tag $BOT_TEMP_IMAGE lappis/bot:latest
-    - docker push lappis/bot:latest
+    - docker tag $BOT_TEMP_IMAGE lappis/bot:tais
+    - docker push lappis/bot:tais
   only:
     - master
   environment: homolog
@@ -110,8 +110,8 @@ build web:
     - docker:dind
   script:
     - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
-    - docker build -f docker/web/web.Dockerfile -t lappis/bot-web:latest .
-    - docker push lappis/bot-web:latest
+    - docker build -f docker/web/web.Dockerfile -t lappis/bot-web:tais .
+    - docker push lappis/bot-web:tais
   only:
     - master
   environment: homolog

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ test stories:
  services:
    - docker:dind
  script:
-   - docker build . -f docker/bot/coach.Dockerfile -t lappis/coach:tais > /dev/null 2>&1 # Builds lappis/coach:tais
+   - docker build . -f docker/bot/coach.Dockerfile -t lappis/coach:tais # Builds lappis/coach:tais
    - docker build -f docker/bot/bot.Dockerfile -t $BOT_TEMP_IMAGE . # It uses lappis/coach:tais built locally
    - docker run --rm $BOT_TEMP_IMAGE make test-stories
    - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 train: 
-	docker build . -f docker/bot/coach.Dockerfile -t lappis/coach:latest
+	docker build . -f docker/bot/coach.Dockerfile -t lappis/coach:tais
 	docker-compose build bot
 
 test-dialogue:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ make train
 Caso queira atualizar o treinamento padrão da aplicação, será necessário atualizar a versão da imagem Coach no dockerhub do lappis:
 ```bash
 make train
-sudo docker push lappis/coach:latest
+sudo docker push lappis/coach:tais
 ```
 
 ## Site do Beta

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   # ================================= Bot =====================================
   bot:
-    image: lappis/bot:latest
+    image: lappis/bot:tais
     build:
       context: .
       dockerfile: ./docker/bot/bot.Dockerfile
@@ -48,7 +48,7 @@ services:
 
   # =================================== Web ===================================
   web:
-    image: lappis/web:latest
+    image: lappis/web:tais
     build:
       context: .
       dockerfile: ./docker/web/web.Dockerfile

--- a/docker/bot/bot.Dockerfile
+++ b/docker/bot/bot.Dockerfile
@@ -1,6 +1,6 @@
-FROM lappis/coach:latest as coach
+FROM lappis/coach:tais as coach
 
-FROM lappis/botrequirements:latest
+FROM lappis/botrequirements:tais
 
 COPY ./bot /bot
 COPY --from=coach /src_models/ /models/

--- a/docker/bot/build-base.sh
+++ b/docker/bot/build-base.sh
@@ -5,7 +5,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-base_image=lappis/botrequirements:latest
+base_image=lappis/botrequirements:tais
 
 # Build base image
 docker build . -f requirements.Dockerfile -t $base_image

--- a/docker/bot/coach.Dockerfile
+++ b/docker/bot/coach.Dockerfile
@@ -1,4 +1,4 @@
-FROM lappis/botrequirements:latest
+FROM lappis/botrequirements:tais
 
 COPY ./coach /coach
 COPY ./scripts /scripts

--- a/docker/notebooks/notebooks.Dockerfile
+++ b/docker/notebooks/notebooks.Dockerfile
@@ -1,4 +1,4 @@
-FROM lappis/botrequirements:latest
+FROM lappis/botrequirements:tais
 
 
 COPY ./docs/tutoriais/ /work/tutoriais/

--- a/docs/documentacao/arquitetura.md
+++ b/docs/documentacao/arquitetura.md
@@ -74,7 +74,7 @@ Dentro da arquitetura da TAIS utiliza-se serviços baseado em `Docker`, sendo as
 A imagem `docker` utilizada no serviço de *Trainer* é construída a partir do `Dockerfile` abaixo. É nesta imagem onde estarão os diretórios de `intents` e `stories` do `Rasa` que formam a base de conhecimentos do *bot*. Também é nesta imagem onde estarão os modelos treinados.
 
 ```Dockerfile
-FROM lappis/botrequirements:latest
+FROM lappis/botrequirements:tais
 
 COPY ./coach /coach
 COPY ./scripts /scripts
@@ -88,7 +88,7 @@ RUN make train
 RUN find /. | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
 ```
 
-A imagem `lappis/botrequirements:latest` possui todas as dependências `Rasa` pré instaladas e é utilizada como base para este serviço e o serviço de bot, explicado na próxima seção deste documento.
+A imagem `lappis/botrequirements:tais` possui todas as dependências `Rasa` pré instaladas e é utilizada como base para este serviço e o serviço de bot, explicado na próxima seção deste documento.
 
 Uma vez que os parâmetros da rede estão bem definidos e o *dataset* do *bot* está finalizado, o processo de treinamento será realizado apenas uma vez, e o mesmo modelo será utilizado sempre que se desejar executar aquele estado de treinamento. Com essa abordagem o versionamento dos modelos do *bot* é feito a partir das *tags* do `docker`, sendo que cada *tag* da imagem de *trainer* reflete uma versão da base de conhecimentos e das configurações de rede utilizadas em um determinado momento.
 
@@ -99,9 +99,9 @@ Isto permite criar facilmente estratégias como a representada no diagrama acima
 O Bot se utiliza dos modelos pré-treinados do *trainer* e do `Rasa` para execução do *bot*. Este módulo é utilizado também através de um serviço executado à partir de um *container* `Docker`. A imagem utilizada neste serviço é gerada à partir do Dockerfile abaixo:
 
 ```Dockerfile
-FROM lappis/coach:latest as coach
+FROM lappis/coach:tais as coach
 
-FROM lappis/botrequirements:latest
+FROM lappis/botrequirements:tais
 
 COPY ./bot /bot
 COPY --from=coach /src_models/ /models/
@@ -129,9 +129,9 @@ Quando se utiliza um `Dockerfile` a linha definida com a palavra `FROM` indica a
 
 No `Dockerfile` acima pode-se notar que a palavra `FROM` foi utilizada duas vezes, o objetivo disto é utilizar um recurso do `docker` chamado [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/).
 
-O que a linha `FROM lappis/coach:latest as coach` faz é criar uma referência à imagem `lappis/coach` com o nome de `coach`.
-Depois disso a imagem de base é redefinida na linha `FROM lappis/botrequirements:latest` como sendo a imagem de *requirements* onde já estão instaladas as dependências do `Rasa` necessárias para a execução do *bot*.
-Como a referência à primeira imagem de base foi definida como `coach`, na linha `COPY --from=coach /src_models/ /models/` o diretório de modelos pode ser copiado da primeira imagem de base para a segunda imagem de base. O resultado disso é que a imagem final será criada a partir da imagem `lappis/botrequirements:latest`, mas dentro dela estarão os modelos copiados da imagem `lappis/coach:latest`.
+O que a linha `FROM lappis/coach:tais as coach` faz é criar uma referência à imagem `lappis/coach` com o nome de `coach`.
+Depois disso a imagem de base é redefinida na linha `FROM lappis/botrequirements:tais` como sendo a imagem de *requirements* onde já estão instaladas as dependências do `Rasa` necessárias para a execução do *bot*.
+Como a referência à primeira imagem de base foi definida como `coach`, na linha `COPY --from=coach /src_models/ /models/` o diretório de modelos pode ser copiado da primeira imagem de base para a segunda imagem de base. O resultado disso é que a imagem final será criada a partir da imagem `lappis/botrequirements:tais`, mas dentro dela estarão os modelos copiados da imagem `lappis/coach:tais`.
 
 ## Business Analytics
 

--- a/docs/tutoriais/notebooks/pipeline-de-qualidade.ipynb
+++ b/docs/tutoriais/notebooks/pipeline-de-qualidade.ipynb
@@ -101,14 +101,14 @@
    "source": [
     "run dataset validator:\n",
     "  stage: validate format\n",
-    "  image: lappis/coach:latest\n",
+    "  image: lappis/coach:tais\n",
     "  script:\n",
     "    - cd coach/\n",
     "    - make run-validator\n",
     "\n",
     "test stories:\n",
     "  stage: test stories\n",
-    "  image: lappis/bot:latest\n",
+    "  image: lappis/bot:tais\n",
     "  script:\n",
     "    - cd bot/\n",
     "    - make test-stories"

--- a/docs/tutoriais/notebooks/tutorial-pipeline-de-bot.ipynb
+++ b/docs/tutoriais/notebooks/tutorial-pipeline-de-bot.ipynb
@@ -48,7 +48,7 @@
     "\n",
     "run dataset validator:\n",
     "  stage: validate format\n",
-    "  image: lappis/coach:latest\n",
+    "  image: lappis/coach:tais\n",
     "  script:\n",
     "    - cd coach/\n",
     "    - make run-validator"
@@ -58,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "No exemplo acima, foi definida uma imagem base chamada `python:3.6-slim`. Em seguida foram definidos dois *jobs* de teste, o primeiro deles utilizará a imagem padrão do python que foi definida na primeira linha, já que este não possui nenhuma *tag* de definição de imagem. O segundo *job* utilizará a imagem `lappis/coach:latest`, já que possui uma *tag* de definição de imagem que sobreescreve a imagem base.\n",
+    "No exemplo acima, foi definida uma imagem base chamada `python:3.6-slim`. Em seguida foram definidos dois *jobs* de teste, o primeiro deles utilizará a imagem padrão do python que foi definida na primeira linha, já que este não possui nenhuma *tag* de definição de imagem. O segundo *job* utilizará a imagem `lappis/coach:tais`, já que possui uma *tag* de definição de imagem que sobreescreve a imagem base.\n",
     "\n",
     "## Definição dos stages\n",
     "\n",
@@ -123,8 +123,8 @@
     "    - docker:dind\n",
     "  script:\n",
     "    - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD\n",
-    "    - docker build -f docker/bot/bot.Dockerfile -t lappis/bot:latest .\n",
-    "    - docker push lappis/bot:latest\n",
+    "    - docker build -f docker/bot/bot.Dockerfile -t lappis/bot:tais .\n",
+    "    - docker push lappis/bot:tais\n",
     "  only:\n",
     "    - master\n",
     "  environment: homolog"

--- a/docs/tutoriais/pipeline-de-qualidade.md
+++ b/docs/tutoriais/pipeline-de-qualidade.md
@@ -65,14 +65,14 @@ Após isso foram definidas duas *tasks* simples para validação dos parâmetros
 ```yml
 run dataset validator:
   stage: validate format
-  image: lappis/coach:latest
+  image: lappis/coach:tais
   script:
     - cd coach/
     - make run-validator
 
 test stories:
   stage: test stories
-  image: lappis/bot:latest
+  image: lappis/bot:tais
   script:
     - cd bot/
     - make test-stories

--- a/docs/tutoriais/tutorial-pipeline-de-bot.md
+++ b/docs/tutoriais/tutorial-pipeline-de-bot.md
@@ -29,13 +29,13 @@ test style:
 
 run dataset validator:
   stage: validate format
-  image: lappis/coach:latest
+  image: lappis/coach:tais
   script:
     - cd coach/
     - make run-validator
 ```
 
-No exemplo acima, foi definida uma imagem base chamada `python:3.6-slim`. Em seguida foram definidos dois *jobs* de teste, o primeiro deles utilizará a imagem padrão do python que foi definida na primeira linha, já que este não possui nenhuma *tag* de definição de imagem. O segundo *job* utilizará a imagem `lappis/coach:latest`, já que possui uma *tag* de definição de imagem que sobreescreve a imagem base.
+No exemplo acima, foi definida uma imagem base chamada `python:3.6-slim`. Em seguida foram definidos dois *jobs* de teste, o primeiro deles utilizará a imagem padrão do python que foi definida na primeira linha, já que este não possui nenhuma *tag* de definição de imagem. O segundo *job* utilizará a imagem `lappis/coach:tais`, já que possui uma *tag* de definição de imagem que sobreescreve a imagem base.
 
 ## Definição dos stages
 
@@ -70,8 +70,8 @@ build bot:
     - docker:dind
   script:
     - docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASSWORD
-    - docker build -f docker/bot/bot.Dockerfile -t lappis/bot:latest .
-    - docker push lappis/bot:latest
+    - docker build -f docker/bot/bot.Dockerfile -t lappis/bot:tais .
+    - docker push lappis/bot:tais
   only:
     - master
   environment: homolog


### PR DESCRIPTION
Since there are 3 different bot projects inside lappis org, and all of them push images to dockerhub, to avoid image conflicts, there should be a specific tag for each project. This PR changes all the "latest" tags to "tais".